### PR TITLE
chore: sample中增加多行标题的示例

### DIFF
--- a/pages/paper-cover.typ
+++ b/pages/paper-cover.typ
@@ -26,38 +26,71 @@
     #v(20pt)
 
     #let info_value(body) = {
+      // 判断 body 是否为数组
+      if type(body) == array {
+        // 如果是数组，遍历每一项并生成多个 rect
+        [
+          #for item in body {
+            // v(0pt) 
+            rect(
+              width: 100%,
+              inset: (x: 1pt, bottom: 1pt),
+              stroke: (
+                bottom: 1pt + black,
+              ),
+              text(
+                font: fangsong,
+                size: 16pt,
+                bottom-edge: "descender",
+                weight: "bold",
+              )[
+                #item
+              ]
+            )
+            v(-8pt)
+          }
+        ]
+        v(8pt)
+      } else {
+        // 如果不是数组（即普通文本），保持原有逻辑不变
+        rect(
+          width: 100%,
+          inset: (x: 1pt, top: 7pt, bottom: 1pt),
+          stroke: (
+            bottom: 1pt + black,
+          ),
+          text(
+            font: fangsong,
+            size: 16pt,
+            bottom-edge: "descender",
+            weight: "bold",
+          )[
+            #body
+          ]
+        )
+      }
+    }
+    
+    #let info_key(body) = {
       rect(
-        width: 100%,
-        inset: 1pt,
-        stroke: (
-          bottom: 1pt + black,
-        ),
+        // width: 100%,
+        inset: (x: 1pt, y: 4pt),
+        stroke: none,
         text(
           font: fangsong,
           size: 16pt,
-          bottom-edge: "descender",
           weight: "bold",
         )[
           #body
         ]
-      ) 
-    }
-    
-    #let info_key(body) = {
-      text(
-        font: fangsong,
-        size: 16pt,
-        weight: "bold",
-      )[
-        #body
-      ]
+      )
     }
 
     #v(20pt)
 
     #grid(
       columns: (70pt, 300pt),
-      rows: (25pt),
+      rows: (auto),
       gutter: 3pt,
       info_key("题　　目"),
       info_value(title),

--- a/pages/paper-cover.typ
+++ b/pages/paper-cover.typ
@@ -55,7 +55,7 @@
         // 如果不是数组（即普通文本），保持原有逻辑不变
         rect(
           width: 100%,
-          inset: (x: 1pt, top: 7pt, bottom: 1pt),
+          inset: (x: 1pt, top: 5.5pt, bottom: 1pt),
           stroke: (
             bottom: 1pt + black,
           ),
@@ -73,8 +73,8 @@
     
     #let info_key(body) = {
       rect(
-        // width: 100%,
-        inset: (x: 1pt, y: 4pt),
+        width: 100%,
+        inset: (x: 1pt, y: 5.5pt),
         stroke: none,
         text(
           font: fangsong,

--- a/templates/cs-template.typ
+++ b/templates/cs-template.typ
@@ -60,9 +60,15 @@
   /* 封面与原创性声明 */
 
   // 封面
-  paper_cover(cover_logo_path: "../assets/scu_black.png", 
-    anonymous, title, school, author, id, mentor, date, grade, major
-  )
+  if (title_array != ()) {
+    paper_cover(cover_logo_path: "../assets/scu_black.png", 
+      anonymous, title_array, school, author, id, mentor, date, grade, major
+    )
+  } else {
+    paper_cover(cover_logo_path: "../assets/scu_black.png", 
+      anonymous, title, school, author, id, mentor, date, grade, major
+    )
+  }
 
   /* 目录与摘要 */
   // 整体页眉


### PR DESCRIPTION
增加了示例的代码和更新pdf，并补上cs-template.typ中漏的传参定义：

```typst
#show: project.with(
  anonymous: false,
  title: "基于Typst的川大计院毕业论文模版",
  title_array: (
    "(可选)用于标题过长的情况",
    "基于Typst的川大计院毕业论文模版"
  ),
  author: "你的名字",
  下省略
```

~~大佬还在线啊~~